### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/AllegroTechies/809fbbc7-26f8-474d-b81b-828800713cbc/f376cb8d-f0e2-4200-a38a-7e418a8fd875/_apis/work/boardbadge/8ef88591-7492-421d-8dee-ad3d171b2faf)](https://dev.azure.com/AllegroTechies/809fbbc7-26f8-474d-b81b-828800713cbc/_boards/board/t/f376cb8d-f0e2-4200-a38a-7e418a8fd875/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#19115](https://dev.azure.com/AllegroTechies/809fbbc7-26f8-474d-b81b-828800713cbc/_workitems/edit/19115). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.